### PR TITLE
link to latest api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ let bittrex_client = BittrexClient::new("KEY".to_string(), "SECRET".to_string())
 let markets = bittrex_client.get_markets().unwrap(); //Get all available markets of Bittrex
 ```
 
-See the [Documentation](https://docs.rs/bittrex-api/0.2.0/bittrex_api/) for more information about the various wrapper functions.
+See the [Documentation](https://docs.rs/bittrex-api) for more information about the various wrapper functions.


### PR DESCRIPTION
the link was going to 0.2.0 which seems odd, makes more sense to just link to latest